### PR TITLE
Don't set SECRET_KEY if it is not set

### DIFF
--- a/django12factor/__init__.py
+++ b/django12factor/__init__.py
@@ -1,7 +1,6 @@
 import django_cache_url
 import dj_database_url
 import dj_email_url
-import uuid
 import os
 import logging
 
@@ -33,12 +32,8 @@ def factorise():
 
     settings = {}
 
-    # Slightly opinionated...
     if 'SECRET_KEY' in os.environ:
         settings['SECRET_KEY'] = os.environ['SECRET_KEY']
-    else:
-        logger.warn('No SECRET_KEY provided, using UUID')
-        settings['SECRET_KEY'] = str(uuid.uuid4())
 
     settings['LOGGING'] = {
         'version': 1,


### PR DESCRIPTION
Currently, if `SECRET_KEY` is not in the environment, django12factor will log a warning, generate a random value, and carry on.

The value of `SECRET_KEY` is used internally by Django for [cryptographic signing](https://docs.djangoproject.com/en/dev/topics/signing/) so its value is kind of sacred.

Using a value for `SECRET_KEY` which changes on every startup is a bad idea because it will render any existing signed data as invalid. This would be especially frustrating during development when the server reboots due to a code change, and the reason why things such as signed cookies no longer work would be non-obvious.

An alternative of generating the value statically (for example, `SECRET_KEY=socket.gethostname()` would alleviate that problem, but introduces potential security problems. For example, if an application is running production without the `SECRET_KEY` explicitly set, then it will be implicitly set. If an attacker can work out the parameters used to set the key (for example, the hostname), then they are easily able to sign data, which would enable them to create 'reset password' links for example.
