### PR TITLE
Removed warning regarding :memory: sqlite URI

### DIFF
--- a/django12factor/__init__.py
+++ b/django12factor/__init__.py
@@ -51,7 +51,7 @@ def factorise():
     }
 
     settings['DATABASES'] = {
-        'default': dj_database_url.config(default='sqlite://:memory:') # Note this'll currently break due to https://github.com/kennethreitz/dj-database-url/pull/21
+        'default': dj_database_url.config(default='sqlite://:memory:')
     }
 
     settings['DEBUG'] = getenv_bool('DEBUG')


### PR DESCRIPTION
dj-database-url 0.2.2 has merged in the change required to handle :memory: URIs.
