### PR TITLE
Dependency version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 * Nothing!
 
+## 1.2
+
+* Update dependencies
+
 ## 1.1
 
 * Grab arbitrary environment variables as settings with the `custom_settings` parameter

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 import sys
 from setuptools import setup, find_packages
 
-__version__ = '1.1'
+__version__ = '1.2'
 
 HERE = os.path.dirname(__file__)
 


### PR DESCRIPTION
I found out that LP single-pass provisioning is currently breaking because Spiderman depends on dj-database-url 0.3.0. So I thought that it's time for a version bump on django12factor.
