### PR TITLE
Pip has deprecated `--use-mirrors`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,5 @@ python:
   - "3.3"
   - "3.4"
 install:
-  - "pip install --use-mirrors --editable ."
+  - "pip install --editable ."
 script: "nosetests"


### PR DESCRIPTION
http://pip.readthedocs.org/en/1.5.X/news.html
