### PR TITLE
Move "test dependencies" out to requirements-test.txt and pin versions

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,5 @@
+coverage==3.7.1
+git+https://github.com/doismellburning/doc8.git@feature/display-line-lengths
+flake8==2.3.0
+nose==1.3.4
+pygments==2.0.2

--- a/tox.ini
+++ b/tox.ini
@@ -10,22 +10,17 @@ envlist =
 
 [testenv]
 deps =
-	nose
-	coverage
+	-rrequirements-test.txt
 commands =
 	coverage run {envdir}/bin/nosetests
 	coverage report
 
 
 [testenv:flake8]
-deps = flake8
 commands =
 	flake8 django12factor tests setup.py
 
 
 [testenv:doc8]
-deps =
-	git+https://github.com/doismellburning/doc8.git@feature/display-line-lengths
-	pygments
 commands =
 	doc8 README.rst


### PR DESCRIPTION
requires.io plays better with requirements.txt files, and the lack of
pinning was the source of woe