### PR TITLE
Drop Python 3.2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ env:
     - TOXENV=flake8
     - TOXENV=pep257
     - TOXENV=py27
-    - TOXENV=py32
     - TOXENV=py33
     - TOXENV=py34
 install:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Dropped Python 3.2 support
+
 ## 1.3
 
 * Python 3.2 and 3.4 support

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,6 @@ envlist =
 	flake8,
 	pep257,
 	py27,
-	py32,
 	py33,
 	py34,
 	sphinx,


### PR DESCRIPTION
https://www.python.org/dev/peps/pep-0392/

> 3.2.5 final: May 13, 2013
> -- Only security releases after 3.2.5 --