### PR TITLE
Don't set deprecated settings on Django 1.8 and above

### DIFF
--- a/django12factor/__init__.py
+++ b/django12factor/__init__.py
@@ -9,6 +9,7 @@ django12factor: Bringing 12factor configuration to Django.
 import django_cache_url
 import dj_database_url
 import dj_email_url
+import django
 import os
 import logging
 import six
@@ -104,10 +105,11 @@ def factorise(custom_settings=None):
             settings['DATABASES'][dbname] = db
 
     settings['DEBUG'] = getenv_bool('DEBUG')
-    if 'TEMPLATE_DEBUG' in os.environ:
-        settings['TEMPLATE_DEBUG'] = getenv_bool('TEMPLATE_DEBUG')
-    else:
-        settings['TEMPLATE_DEBUG'] = settings['DEBUG']
+    if django.VERSION < (1, 8):
+        if 'TEMPLATE_DEBUG' in os.environ:
+            settings['TEMPLATE_DEBUG'] = getenv_bool('TEMPLATE_DEBUG')
+        else:
+            settings['TEMPLATE_DEBUG'] = settings['DEBUG']
 
     # Slightly opinionated...
     if 'SECRET_KEY' in os.environ:

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
         "dj-email-url==0.0.8",
         "django-cache-url==1.2.0",
         "six",
+        "django",
     ),
 
     tests_require=(

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os
 from setuptools import setup, find_packages
 
-__version__ = '1.3'
+__version__ = '1.4.dev'
 
 HERE = os.path.dirname(__file__)
 

--- a/tests/test_d12f.py
+++ b/tests/test_d12f.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 import django12factor
 import unittest
+import django
 
 from .env import env
 
@@ -30,6 +31,9 @@ class TestD12F(unittest.TestCase):
             self.assertFalse(d12f()['DEBUG'])
 
     def test_template_debug(self):
+        # for this test, we pretend to be Django < 1.8
+        oldversion = django.VERSION
+        django.VERSION = (1, 7, 0, "test_template_debug", 1)
         with debugenv():
             # Unless explicitly set, TEMPLATE_DEBUG = DEBUG
             self.assertTrue(d12f()['TEMPLATE_DEBUG'])
@@ -38,6 +42,7 @@ class TestD12F(unittest.TestCase):
             s = d12f()
             self.assertFalse(s['TEMPLATE_DEBUG'])
             self.assertTrue(s['DEBUG'])
+        django.VERSION = oldversion
 
     def test_db(self):
         with debugenv():


### PR DESCRIPTION
One way of addressing #53. 

I also looked at setting 'debug' on all template configs that use the DjangoTemplate backend, but that feels like too much magic. It's much better to just let the user handle the setting through environment variables where needed.
