### PR TITLE
fix feature/stdout-not-stderr tests

### DIFF
--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -89,7 +89,9 @@ class TestLogging(unittest.TestCase):
     def test_logging_to_stdout(self):
         with debug_env:
             with captured_stdout() as stdout:
-                logging.config.dictConfig(django12factor.factorise()["LOGGING"])
+                logging.config.dictConfig(
+                    django12factor.factorise()["LOGGING"]
+                )
                 message = "lorem ipsum"
                 logging.info(message)
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -3,7 +3,9 @@ from __future__ import (
     print_function,
 )
 
-import StringIO
+from contextlib import contextmanager
+
+import six
 import django12factor
 import logging
 import logging.config
@@ -19,17 +21,41 @@ def has_handler(logger, handler_name):
     return any([handler.name == handler_name for handler in logger.handlers])
 
 
-def capture_stdout(command, *args, **kwargs):
-    normal_stdout = sys.stdout
-    captured_stdout = StringIO.StringIO()
-    sys.stdout = captured_stdout
+# Vendored in version of Python's
+# https://docs.python.org/3.5/library/test.html#module-test
+@contextmanager
+def captured_output(stream_name):
+    """Return a context manager used by captured_stdout/stdin/stderr
+    that temporarily replaces the sys stream *stream_name* with a StringIO.
 
-    command(*args, **kwargs)
+    Note: This function and the following ``captured_std*`` are copied
+          from CPython's ``test.support`` module."""
+    orig_stdout = getattr(sys, stream_name)
+    setattr(sys, stream_name, six.StringIO())
+    try:
+        yield getattr(sys, stream_name)
+    finally:
+        setattr(sys, stream_name, orig_stdout)
 
-    captured_stdout.seek(0)
-    sys.stdout = normal_stdout
 
-    return captured_stdout.read()
+def captured_stdout():
+    """Capture the output of sys.stdout:
+
+       with captured_stdout() as stdout:
+           print("hello")
+       self.assertEqual(stdout.getvalue(), "hello\n")
+    """
+    return captured_output("stdout")
+
+
+def captured_stderr():
+    """Capture the output of sys.stderr:
+
+       with captured_stderr() as stderr:
+           print("hello", file=sys.stderr)
+       self.assertEqual(stderr.getvalue(), "hello\n")
+    """
+    return captured_output("stderr")
 
 
 class TestLogging(unittest.TestCase):
@@ -47,25 +73,29 @@ class TestLogging(unittest.TestCase):
         config.
         """
         with debug_env:
-            logging.config.dictConfig(django12factor.factorise()['LOGGING'])
+            logging.config.dictConfig(django12factor.factorise()["LOGGING"])
             self.assertTrue(has_handler(logging.root, "stdout"))
 
     def test_capture_stdout_works_with_print(self):
         """
         Assert that `capture_stdout` captures `print` text
         """
-        output = capture_stdout(print, "wibble")
-        self.assertIn("wibble", output)
+        with debug_env:
+            with captured_stdout() as stdout:
+                print("wibble")
+
+        self.assertIn("wibble", stdout.getvalue())
 
     def test_logging_to_stdout(self):
-
         with debug_env:
-            logging.config.dictConfig(django12factor.factorise()['LOGGING'])
+            with captured_stdout() as stdout:
+                logging.config.dictConfig(django12factor.factorise()["LOGGING"])
+                message = "lorem ipsum"
+                logging.info(message)
 
-            message = "lorem ipsum"
-            output = capture_stdout(logging.info, message)
-            self.assertIn(
-                message, output,
-                "Message '%s' should have been logged to stdout and captured;"
-                "instead '%s' was captured" % (message, output)
-            )
+        output = stdout.getvalue()
+        self.assertIn(
+            message, output,
+            "Message '%s' should have been logged to stdout and captured;"
+            "instead '%s' was captured" % (message, output)
+        )


### PR DESCRIPTION
This PR uses a vendored capture_stdout context manager for logging tests with correct stdout configuration as proposed on doismellburning/django12factor#32.

Because I really really want 12factor-correct logging at some point ;)
