### PR TITLE
Use sqlite:///db.sqlite3 as the default DATABASE_URL

### DIFF
--- a/django12factor/__init__.py
+++ b/django12factor/__init__.py
@@ -72,7 +72,7 @@ def factorise(custom_settings=None):
     }
 
     settings['DATABASES'] = {
-        'default': dj_database_url.config(default='sqlite://:memory:')
+        'default': dj_database_url.config(default='sqlite:///db.sqlite3')
     }
 
     for (key, value) in six.iteritems(os.environ):


### PR DESCRIPTION
Django is unusable with in-memory SQLite, because there is no way to run both migrate and runserver on the same one. It's better to provide a default that's usable (and usually perfect) on development environments.