### PR TITLE
Use localhost as the default ALLOWED_HOSTS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Dropped Python 3.2 support
+* Use localhost as the default ALLOWED_HOSTS
 
 ## 1.3
 

--- a/django12factor/__init__.py
+++ b/django12factor/__init__.py
@@ -125,7 +125,7 @@ safety reasons""")
 
     settings.update(dj_email_url.config(default='dummy://'))
 
-    settings['ALLOWED_HOSTS'] = os.getenv('ALLOWED_HOSTS', '').split(',')
+    settings['ALLOWED_HOSTS'] = os.getenv('ALLOWED_HOSTS', 'localhost').split(',')
 
     # For keys to different apis, etc.
     if custom_settings is None:


### PR DESCRIPTION
Seems like a better default value, because it's one less param required for starting local development environments with debug off.

I don't think this is a security problem on production - because production deployments won't work without setting it to a real domain.