### PR TITLE
Don't depend on exact versions of dj-database/email/cache-url

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,9 +27,9 @@ setup(
     keywords='django 12factor configuration',
 
     install_requires=(
-        "dj-database-url==0.4.2",
-        "dj-email-url==0.0.10",
-        "django-cache-url==1.3.1",
+        "dj-database-url",
+        "dj-email-url",
+        "django-cache-url",
         "six",
         "django",
     ),


### PR DESCRIPTION
Current django12factor's release depends on outdated ones, which means users don't get useful bugfixes.