### PR TITLE
Update "give me everything" instructions

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -79,7 +79,8 @@ If you say so...
 .. code-block:: python
 
     import django12factor
-    globals().update(django12factor.factorise())
+    d12f = django12factor.factorise()
+    globals().update(d12f)
 
 Utilities
 ---------


### PR DESCRIPTION
Getting up and running with `django12factor`, I found that following the "give me everything" instructions caused Django to fail silently.

I'd forgotten to install `psycopg2`, so my database URL was causing `django.core.exceptions.ImproperlyConfigured: Error loading psycopg2 module: No module named 'psycopg2'`. However, this wasn't being reported anywhere obvious. Django just silently exited. I suspect this is because Django's logging config is in some kind of flux at this moment, but I'm not sure.

By breaking out `django12factor.factorise()` into a separate line, Django's default logging is able to report this error.

Using the following versions:

```
django12factor==1.3
django==2.1
```