### PR TITLE
bump version for release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os
 from setuptools import setup, find_packages
 
-__version__ = '1.3'
+__version__ = '1.4'
 
 HERE = os.path.dirname(__file__)
 


### PR DESCRIPTION
@doismellburning 5 years ago I removed the pinned versions from setup.py. And then we never published a new package on pypi. So 1.3 which is still on pypi, still has pinned super-old versions of the dependencies. Let's fix that :)